### PR TITLE
[FEAT] add a new page for the keyword analysis / add add search keyword in the keyword-analysis tooltip message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 # /Depreciated_UniCenter_backend
 /fe-backend/node_modules
 /src/app/ip.service.ts
+# data team
+/fe-backend/server.js
 
 # IDEs and editors
 /.idea

--- a/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.html
+++ b/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.html
@@ -1,0 +1,19 @@
+<div class="research-status-container">
+  <section class="research-status">
+    <div class="header">
+      <h1>키워드 분석</h1>
+      <button class="save-graph-button">담기</button>
+    </div>
+<!--    <section *ngIf="isChartLoaded" class="chart-wrapper">-->
+<!--      <canvas-->
+<!--        baseChart-->
+<!--        [data]="chartData"-->
+<!--        [labels]="chartLabels"-->
+<!--        [chartType]="chartType"-->
+<!--        [options]="chartOptions"-->
+<!--        [plugins]="chartPlugins"-->
+<!--        [legend]="chartLegend">-->
+<!--      </canvas>-->
+<!--    </section>-->
+  </section>
+</div>

--- a/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.less
+++ b/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.less
@@ -1,0 +1,134 @@
+@media all and (min-width: 1441px) {
+  .research-status-container {
+    grid-area            : main;
+    display              : grid;
+    align-content        : stretch;
+    grid-template-columns: repeat(15, minmax(0, 1fr));
+    grid-template-rows   : 1fr;
+    gap                  : 20px 20px;
+    grid-template-areas  : ". . . body body body body body body body body body body body body ";
+    height               : 100%;
+  }
+}
+
+@media all and (min-width: 1025px) and (max-width: 1440px) {
+  .research-status-container {
+    grid-area            : main;
+    display              : grid;
+    align-content        : stretch;
+    grid-template-columns: repeat(14, minmax(0, 1fr));
+    grid-template-rows   : 1fr;
+    gap                  : 20px 20px;
+    grid-template-areas  : ". . body body body body body body body body body body body body";
+    height               : 100%;
+  }
+}
+
+@media all and (min-width: 769px) and (max-width: 1024px) {
+  .research-status-container {
+    grid-area            : main;
+    display              : grid;
+    align-content        : stretch;
+    grid-template-columns: repeat(13, minmax(0, 1fr));
+    grid-template-rows   : 1fr;
+    gap                  : 20px 20px;
+    grid-template-areas  : " . body body body body body body body body body body body body  ";
+    height               : 100%;
+  }
+}
+
+
+.research-status {
+  grid-area: body;
+}
+
+.chart-wrapper {
+  margin-top   : 20px;
+  border-radius: 25px;
+  border       : 1px solid #52b9ff;
+  padding      : 5% 10%;
+  margin       : 0% 20%;
+}
+
+h1 {
+  font-size  : 20px;
+  font-weight: 700;
+  margin     : 20px 0;
+  color      : #52b9ff;
+}
+
+.save-graph-button {
+  height             : -webkit-fit-content;
+  height             : -moz-fit-content;
+  height             : fit-content;
+  border-radius      : 35px;
+  border             : none;
+  font-size          : 1.5rem;
+  text-align         : end;
+  color              : white;
+  background-color   : #52b9ff;
+  outline            : none;
+  padding            : 0.3em 1em;
+  padding-left       : 2.5em;
+  background-image   : url(../../../../../assets/icons/save-doc.png);
+  background-repeat  : no-repeat;
+  background-position: left 1em center;
+  background-size    : 1em;
+}
+
+.header {
+  display        : flex;
+  justify-content: space-between;
+  align-items    : center;
+  margin         : 0 15%;
+}
+
+@media all and (min-width: 426px) and (max-width: 768px){
+  .research-status-container {
+    grid-area            : main;
+    display              : grid;
+    align-content        : stretch;
+    grid-template-columns: repeat(13, minmax(0, 1fr));
+    grid-template-rows   : 1fr;
+    gap                  : 20px 20px;
+    grid-template-areas  : " body body body body body body body body body body body body body  ";
+    height               : 100%;
+  }
+
+  .header{
+    font-size: 1em !important;
+  }
+
+  .chart-wrapper {
+    margin       : 0% 10%;
+  }
+
+  .save-graph-button {
+    font-size : 1.2rem;
+  }
+}
+
+@media all and (max-width: 425px){
+  .research-status-container {
+    grid-area            : main;
+    display              : grid;
+    align-content        : stretch;
+    grid-template-columns: repeat(13, minmax(0, 1fr));
+    grid-template-rows   : 1fr;
+    gap                  : 20px 20px;
+    grid-template-areas  : " body body body body body body body body body body body body body  ";
+    height               : 100%;
+  }
+
+  .chart-wrapper {
+    margin       : auto;
+    padding : 0;
+    width : 250px;
+    height: 250px;
+  }
+
+  .chart-wrapper>canvas{
+    width : 200% !important;
+    height : 100% !important;
+  }
+}

--- a/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.spec.ts
+++ b/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { KeywordAnalysisComponent } from './keyword-analysis.component';
+
+describe('KeywordAnalysisComponent', () => {
+  let component: KeywordAnalysisComponent;
+  let fixture: ComponentFixture<KeywordAnalysisComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ KeywordAnalysisComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KeywordAnalysisComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.ts
+++ b/src/app/features/search-result/components/keyword-analysis/keyword-analysis.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-keyword-analysis',
+  templateUrl: './keyword-analysis.component.html',
+  styleUrls: ['./keyword-analysis.component.less']
+})
+export class KeywordAnalysisComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/features/search-result/components/search-result-filter/search-result-filter.component.html
+++ b/src/app/features/search-result/components/search-result-filter/search-result-filter.component.html
@@ -4,7 +4,7 @@
             (click)="toKeywordAnalysis()"
     >키워드분석</button>
     <div class="helper">
-      <span class="arrow-box">검색어에 대한 키워드 분석을 제공합니다.</span>
+      <span class="arrow-box">검색어 "{{ searchKeyword }}" 에 대한 키워드 분석을 제공합니다.</span>
     </div>
     <button
       class="research-result-mobile-run"

--- a/src/app/features/search-result/components/search-result-filter/search-result-filter.component.html
+++ b/src/app/features/search-result/components/search-result-filter/search-result-filter.component.html
@@ -1,6 +1,8 @@
 <section class="filter-container">
   <div class="keyword-analysis">
-    <button class="keyword-analysis-run">키워드분석</button>
+    <button class="keyword-analysis-run"
+            (click)="toKeywordAnalysis()"
+    >키워드분석</button>
     <div class="helper">
       <span class="arrow-box">검색어에 대한 키워드 분석을 제공합니다.</span>
     </div>

--- a/src/app/features/search-result/components/search-result-filter/search-result-filter.component.ts
+++ b/src/app/features/search-result/components/search-result-filter/search-result-filter.component.ts
@@ -48,7 +48,7 @@ export class SearchResultFilterComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.loadInstitutions();
       });
-    this.searchSubscribe = this.elasticsearchService
+    this.searchSubscriber = this.elasticsearchService
       .getSearchStatus()
       .subscribe(() => {
         this.setSearchKeyword();

--- a/src/app/features/search-result/components/search-result-filter/search-result-filter.component.ts
+++ b/src/app/features/search-result/components/search-result-filter/search-result-filter.component.ts
@@ -12,9 +12,11 @@ import {Router} from '@angular/router';
   styleUrls: ["./search-result-filter.component.less"],
 })
 export class SearchResultFilterComponent implements OnInit, OnDestroy {
+  private searchKeyword: string;
 
   private _institutionList: Array<Object>;
   private articleSubscriber: Subscription;
+  private searchSubscriber: Subscription;
   private _selectedInst: string;
   private isSearchFilter: boolean = false;
 
@@ -46,17 +48,23 @@ export class SearchResultFilterComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.loadInstitutions();
       });
+    this.searchSubscribe = this.elasticsearchService
+      .getSearchStatus()
+      .subscribe(() => {
+        this.setSearchKeyword();
+      });
     this._datePickerEndDate = null;
     this._datePickerStartDate = null;
   }
 
   ngOnInit() {
     this.loadInstitutions();
-
+    this.setSearchKeyword();
   }
 
   ngOnDestroy() {
     this.articleSubscriber.unsubscribe();
+    this.searchSubscriber.unsubscribe();
   }
 
   /**
@@ -99,6 +107,14 @@ export class SearchResultFilterComponent implements OnInit, OnDestroy {
 
   selectSearchFilter(): void {
     this.isSearchFilter = !this.isSearchFilter;
+  }
+
+  setSearchKeyword() {
+    this.searchKeyword = this.elasticsearchService.getKeyword();
+  }
+
+  public get getSearchKeyword(): string {
+    return this.searchKeyword;
   }
 
   public get isSelectSearchFilter(): boolean {

--- a/src/app/features/search-result/components/search-result-filter/search-result-filter.component.ts
+++ b/src/app/features/search-result/components/search-result-filter/search-result-filter.component.ts
@@ -4,6 +4,7 @@ import { ElasticsearchService } from "src/app/core/services/elasticsearch-servic
 import {SearchMode} from '../../../../core/enums/search-mode';
 import {ArticleService} from '../../../../core/services/article-service/article.service';
 import {AnalysisDatabaseService} from '../../../../core/services/analysis-database-service/analysis.database.service';
+import {Router} from '@angular/router';
 
 @Component({
   selector: "app-search-result-filter",
@@ -36,7 +37,8 @@ export class SearchResultFilterComponent implements OnInit, OnDestroy {
     "문화",
   ];
 
-  constructor(private elasticsearchService: ElasticsearchService,
+  constructor(private router: Router,
+              private elasticsearchService: ElasticsearchService,
               private articleService: ArticleService,
               private analysisDatabaseService: AnalysisDatabaseService) {
     this.articleSubscriber = this.elasticsearchService
@@ -293,6 +295,9 @@ export class SearchResultFilterComponent implements OnInit, OnDestroy {
 
   }
 
+  toKeywordAnalysis(): void {
+    this.router.navigateByUrl("/search/keywordAnalysis");
+  }
 
   mustKeyword(e) {
     this._mustKeyword = e.target.value.toString();

--- a/src/app/features/search-result/search-result-routing.module.ts
+++ b/src/app/features/search-result/search-result-routing.module.ts
@@ -2,8 +2,13 @@ import { NgModule } from "@angular/core";
 import { Routes, RouterModule } from "@angular/router";
 import { ReadArticle } from "./components/read-article/read-article.component";
 import { SearchResultComponent } from "./components/search-result/search-result.component";
+import { KeywordAnalysisComponent } from './components/keyword-analysis/keyword-analysis.component';
+
 const routes: Routes = [
-  { path: "", redirectTo: "result", pathMatch: "prefix" },
+  {
+    path: "keywordAnalysis",
+    component: KeywordAnalysisComponent,
+  },
   {
     path: "result",
     component: SearchResultComponent,

--- a/src/app/features/search-result/search-result.module.ts
+++ b/src/app/features/search-result/search-result.module.ts
@@ -8,12 +8,14 @@ import { SearchResultFilterComponent } from "./components/search-result-filter/s
 import { ReadArticle } from "./components/read-article/read-article.component";
 import { SharedModule } from "src/app/shared/shared.module";
 import { SearchResultComponent } from "./components/search-result/search-result.component";
+import { KeywordAnalysisComponent } from './components/keyword-analysis/keyword-analysis.component';
 
 @NgModule({
   declarations: [
     SearchResultComponent,
     SearchResultFilterComponent,
     ReadArticle,
+    KeywordAnalysisComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
Add a new page for the keyword analysis.

When clicking the keyword analysis button in the side bar of the search result,
show the new page for keyword analysis.
![image](https://user-images.githubusercontent.com/47239708/148890590-71dda0f3-b2ec-4535-9930-b198d7ea534e.png)

- Issue
1) Less CSS class name should be changed.
2) Contents should be added.
