### PR TITLE
[FIX] 자료열람 기관별 검색 키워드 누락 #142

### DIFF
--- a/src/app/core/services/elasticsearch-service/elasticsearch.service.ts
+++ b/src/app/core/services/elasticsearch-service/elasticsearch.service.ts
@@ -718,11 +718,27 @@ export class ElasticsearchService {
     });
   }
 
+  async getInstitutionsNum() {
+    return await this.client.search({
+      index: this.ipSvc.ES_INDEX,
+      body: {
+        size: 0,
+        aggs: {
+          unique_institutions: {
+            cardinality: {
+              field: "published_institution.keyword",
+            }
+          },
+        },
+      },
+    });
+  }
+
   /**
    * @description Send query of getting all published_institution field value and number of articles for each of the value.
    * @returns query response
    */
-  async getInstitutions(): Promise<any> {
+  async getInstitutions(numInstit?: number): Promise<any> {
     return await this.client.search({
       index: this.ipSvc.ES_INDEX,
       body: {
@@ -730,7 +746,7 @@ export class ElasticsearchService {
         aggs: {
           count: { terms: {
             field: "published_institution.keyword",
-            size: 20
+            size: numInstit
           } },
         },
       },

--- a/src/app/features/article-library/components/article-library-root/article-library.component.ts
+++ b/src/app/features/article-library/components/article-library-root/article-library.component.ts
@@ -91,7 +91,8 @@ export class ArticleLibraryComponent implements OnInit {
    */
   //new
   async loadInstitutions() {
-    let res = await this.elasticsearchService.getInstitutions();
+    let numInstit = await this.elasticsearchService.getInstitutionsNum();
+    let res = await this.elasticsearchService.getInstitutions(numInstit['aggregations']['unique_institutions']['value']);
     let numRes = await this.elasticsearchService.countAllDocs();
     this.institutionList = res["aggregations"]["count"]["buckets"];
     this.totalSavedDocsNum = numRes["count"];


### PR DESCRIPTION
자료열람 페이지에 elasticsearch에 저장되어 있는 모든 기관이 로딩되어 보여질 수 있도록 수정함.
<img width="1624" alt="Screenshot 2023-03-22 at 9 13 51 PM" src="https://user-images.githubusercontent.com/80326384/226902076-67eb45cf-972b-41e7-8612-be0b251fc524.png">
